### PR TITLE
Eliminate file-resolver by iterating locales internally

### DIFF
--- a/lib/expressView.js
+++ b/lib/expressView.js
@@ -16,8 +16,8 @@
  │   limitations under the License.                                            │
  \*───────────────────────────────────────────────────────────────────────────*/
 "use strict";
-var resolver = require('file-resolver');
 var util = require('./util');
+var searchLocales = require('./searchLocales');
 
 var proto = {
 
@@ -31,18 +31,20 @@ var proto = {
         var locals, view, engine;
 
         locals = options && options.context;
-        view = this.resolver.resolve(this.name, util.localityFromLocals(locals));
+        var self = this;
+        searchLocales(self.root, self.name + '.' + self.defaultEngine, [util.localityFromLocals(locals), self.fallback], function (err, view) {
 
-        // This is a bit of a hack to ensure we override `views` for the duration
-        // of the rendering lifecycle. Unfortunately, `adaro` and `consolidate`
-        // (https://github.com/visionmedia/consolidate.js/blob/407266806f3a713240db2285527de934be7a8019/lib/consolidate.js#L214)
-        // check `options.views` but override with `options.settings.views` if available.
-        // So, for this rendering task we need to override with the more specific root directory.
-        options.settings = Object.create(options.settings);
-        options.views = options.settings.views = view.root;
+            // This is a bit of a hack to ensure we override `views` for the duration
+            // of the rendering lifecycle. Unfortunately, `adaro` and `consolidate`
+            // (https://github.com/visionmedia/consolidate.js/blob/407266806f3a713240db2285527de934be7a8019/lib/consolidate.js#L214)
+            // check `options.views` but override with `options.settings.views` if available.
+            // So, for self rendering task we need to override with the more specific root directory.
+            options.settings = Object.create(options.settings);
+            options.views = options.settings.views = view.replace(self.name, '');
 
-        engine = this.engines['.' + this.defaultEngine];
-        engine(view.file, options, callback);
+            engine = self.engines['.' + self.defaultEngine];
+            engine(view, options, callback);
+        });
     }
 
 };
@@ -55,7 +57,7 @@ function buildCtor(fallback) {
         this.root = options.root;
         this.defaultEngine = options.defaultEngine;
         this.engines = options.engines;
-        this.resolver = resolver.create({ root: options.root, ext: this.defaultEngine, fallback: fallback });
+        this.fallback = fallback;
     }
 
     View.prototype = proto;

--- a/lib/searchLocales.js
+++ b/lib/searchLocales.js
@@ -1,0 +1,28 @@
+"use strict";
+
+var bcp47 = require('bcp47');
+var fs = require('fs');
+var path = require('path');
+
+module.exports = function searchLocales(root, name, locales, callback) {
+    if (!locales[0]) {
+        return callback(new Error("not found"));
+    }
+
+    var locale;
+    try {
+        locale = bcp47.parse(locales[0].replace('_', '-')).langtag;
+    } catch (e) {
+        return callback(e);
+    }
+
+    var file = path.join(root, locale.region, locale.language && locale.language.language, name);
+
+    fs.exists(file, function (exists) {
+        if (exists) {
+            return callback(null, file);
+        } else {
+            return searchLocales(root, name, locales.slice(1), callback);
+        }
+    });
+};

--- a/lib/searchLocales.js
+++ b/lib/searchLocales.js
@@ -3,26 +3,28 @@
 var bcp47 = require('bcp47');
 var fs = require('fs');
 var path = require('path');
+var permutron = require('permutron');
 
 module.exports = function searchLocales(root, name, locales, callback) {
-    if (!locales[0]) {
-        return callback(new Error("not found"));
-    }
-
-    var locale;
-    try {
-        locale = bcp47.parse(locales[0].replace('_', '-')).langtag;
-    } catch (e) {
-        return callback(e);
-    }
-
-    var file = path.join(root, locale.region, locale.language && locale.language.language, name);
-
-    fs.exists(file, function (exists) {
-        if (exists) {
-            return callback(null, file);
-        } else {
-            return searchLocales(root, name, locales.slice(1), callback);
+    permutron(root, name, locales, function (root, name, loc, next) {
+        var locale;
+        try {
+            locale = bcp47.parse(loc.replace('_', '-')).langtag;
+        } catch (e) {
+            return callback(e);
         }
+
+        var file = path.join(root, locale.region, locale.language && locale.language.language, name);
+
+        fs.exists(file, function (exists) {
+            if (exists) {
+                return callback(null, file);
+            } else {
+                return next();
+            }
+        });
+    }, function () {
+        return callback(new Error("not found"));
     });
+
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "bcp47": "^1.1.0",
     "bl": "^0.9.0",
-    "file-resolver": "^1.0.0",
     "graceful-fs": "~2.0.1",
     "karka": "~0.0.1",
     "localizr": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "graceful-fs": "~2.0.1",
     "karka": "~0.0.1",
     "localizr": "~1.0.0",
+    "permutron": "^1.0.0",
     "verror": "^1.6.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/krakenjs/engine-munger.git"
   },
   "dependencies": {
+    "bcp47": "^1.1.0",
     "bl": "^0.9.0",
     "file-resolver": "^1.0.0",
     "graceful-fs": "~2.0.1",

--- a/view/js.js
+++ b/view/js.js
@@ -19,26 +19,24 @@
 
 var fs = require('graceful-fs');
 var util = require('../lib/util');
-var resolver = require('file-resolver');
+var searchLocales = require('../lib/searchLocales.js');
 
 exports.create = function (config) {
 
-    var res,
-        defaultLocale = config.i18n.fallback;
-
-    res = resolver.create({ root: config.views, ext: 'js', fallback: defaultLocale });
+    var defaultLocale = config.i18n.fallback;
 
     return function onLoad(name, context, callback) {
         var locals, view;
 
         locals = context.get('context');
 
-        view = res.resolve(name, util.localityFromLocals(locals));
-        if (!view.file) {
-            callback(new Error('Could not load template ' + name));
-            return;
-        }
-        fs.readFile(view.file, 'utf8', callback);
+        searchLocales(config.views, name + '.js', [util.localityFromLocals(locals), defaultLocale], function (err, file) {
+            if (err) {
+                return callback(new Error('Could not load template ' + name));
+            } else {
+                fs.readFile(file, 'utf8', callback);
+            }
+        });
     };
 
 };


### PR DESCRIPTION
This removes the dependency on `file-resolver`, since it's not actually going to be shared algorithm between `engine-munger` and `bundalo`, since content strings will be using a new lookup method.
