### PR TITLE
Added the template name to error messaging when a dust compilation fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 node_modules/
 coverage/
+npm-debug.log

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "engine-munger",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "An engine munger for express apps.",
   "main": "index.js",
   "author": {
@@ -16,7 +16,8 @@
     "file-resolver": "^1.0.0",
     "graceful-fs": "~2.0.1",
     "karka": "~0.0.1",
-    "localizr": "~1.0.0"
+    "localizr": "~1.0.0",
+    "verror": "^1.6.0"
   },
   "devDependencies": {
     "tape": "~2.4.2",

--- a/test/index.js
+++ b/test/index.js
@@ -191,13 +191,13 @@ test('engine-munger', function (t) {
     });
 
 
-    t.test('i18n dust engine- catch error while compiling invalid dust', function(err, data) {
+    t.test('i18n dust engine- catch error while compiling invalid dust and report name of broken template', function(err, data) {
 
         var config = clone(testData['onlyIntl-dust'].config),
             context = clone(testData['onlyIntl-dust'].context);
         resetDust();
         engineMunger.dust(settings, config)('invalidTemp', context, function(err, data) {
-            t.equal(err.message, 'Expected end tag for elements but it was not found. At line : 5, column : 11');
+            t.equal(err.message, 'Problem rendering dust template named invalidTemp: Expected end tag for elements but it was not found. At line : 5, column : 11');
             t.equal(data, undefined);
             t.end();
         });

--- a/view/dust.js
+++ b/view/dust.js
@@ -17,13 +17,13 @@
  \*───────────────────────────────────────────────────────────────────────────*/
 'use strict';
 
-var fs = require('fs'),
-    localizr = require('localizr'),
+var localizr = require('localizr'),
     util = require('../lib/util'),
     dustjs = require('dustjs-linkedin'),
     resolver = require('file-resolver'),
     path = require('path'),
-    bl = require('bl');
+    bl = require('bl'),
+    VError = require('verror');
 
 
 //config has
@@ -57,7 +57,7 @@ exports.create = function (config) {
                 var compiledDust = dustjs.compile(data.toString('utf-8'), name);
                 callback(null, compiledDust);
             } catch (e) {
-                callback(e);
+                callback(new VError(e, 'Problem rendering dust template named %s', name));
             }
         });
 


### PR DESCRIPTION
1. Added VError (Joyent's implementation of wrapped errors)  - see https://www.joyent.com/developers/node/design/errors section "If you pass a lower-level error to your caller, consider wrapping it instead."
2. Updated error test to match.
3. Version bump + misc. minor changes.