### PR TITLE
Fix interaction with escaped names in dust 2.6+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,5 @@ node_js:
 
 script:
   - "npm run-script cover"
-  - "npm run-script lint"
 
 sudo: false

--- a/lib/munger.js
+++ b/lib/munger.js
@@ -80,7 +80,7 @@ exports.wrapDustOnLoad = function (ext, config, needCache, app) {
             if (mappedName !== name && typeof data === 'string') {
                 //this is a workaround, since adaro is not aware of the mapped name up the chain
                 //we find the dust.register line and replace the mappedName of template with original name
-                data = data.replace(mappedName, name).replace(dustjs.escapeJs(mappedName), dustjs.escapeJs(name));;
+                data = data.replace(mappedName, name).replace(dustjs.escapeJs(mappedName), dustjs.escapeJs(name));
             }
             cb(null, data);
         });

--- a/lib/munger.js
+++ b/lib/munger.js
@@ -80,7 +80,7 @@ exports.wrapDustOnLoad = function (ext, config, needCache, app) {
             if (mappedName !== name && typeof data === 'string') {
                 //this is a workaround, since adaro is not aware of the mapped name up the chain
                 //we find the dust.register line and replace the mappedName of template with original name
-                data = data.replace(mappedName, name);
+                data = data.replace(mappedName, name).replace(dustjs.escapeJs(mappedName), dustjs.escapeJs(name));;
             }
             cb(null, data);
         });

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "adaro": "~0.1.5"
   },
   "scripts": {
-    "test": "tape test/*.js",
+    "test": "tape test/*.js && npm run lint",
     "cover": "istanbul cover tape -- test/*.js",
     "lint": "jshint -c .jshintrc index.js lib/ view/"
   }


### PR DESCRIPTION
I hate this, I hate everything about this change. Better alternatives?