### PR TITLE
Do more careful replacement

### DIFF
--- a/lib/munger.js
+++ b/lib/munger.js
@@ -80,9 +80,13 @@ exports.wrapDustOnLoad = function (ext, config, needCache, app) {
             if (mappedName !== name && typeof data === 'string') {
                 //this is a workaround, since adaro is not aware of the mapped name up the chain
                 //we find the dust.register line and replace the mappedName of template with original name
-                data = data.replace(mappedName, name).replace(dustjs.escapeJs(mappedName), dustjs.escapeJs(name));
+                data = data.replace(reg(mappedName), reg(name)).replace(reg(dustjs.escapeJs(mappedName)), reg(dustjs.escapeJs(name)));
             }
             cb(null, data);
         });
     };
 };
+
+function reg(str) {
+    return 'dust.register("' + str + '",';
+}


### PR DESCRIPTION
I am not proud of this solution, but it should be Good Enough(tm) until
we can just recommend that engine-munger be replaced with its new
version, and dust 2.7 used, since dust 2.7 add support for improving
caching and templateName changes.

Fixes https://github.com/krakenjs/kraken-example-with-specialization/issues/2
