### PR TITLE
Fix adaro/dustjs peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "url": "https://github.com/krakenjs/engine-munger.git"
   },
   "dependencies": {
+    "adaro": "~0.1.5",
     "bl": "^0.9.0",
+    "dustjs-linkedin": "~2.6.2",
     "file-resolver": "^1.0.0",
     "graceful-fs": "~2.0.1",
     "karka": "~0.0.1",
@@ -21,17 +23,11 @@
   },
   "devDependencies": {
     "tape": "~2.4.2",
-    "adaro": "~0.1.5",
-    "dustjs-linkedin": "~2.6.2",
     "dustjs-helpers": "~1.6.3",
     "istanbul": "~0.2.4",
     "jshint": "~2.4.3",
     "mockery": "~1.4.0",
     "freshy": "0.0.2"
-  },
-  "peerDependencies": {
-    "dustjs-linkedin": ">= 2.0.0 < 2.7.0",
-    "adaro": "~0.1.5"
   },
   "scripts": {
     "test": "tape test/*.js && npm run lint",


### PR DESCRIPTION
`npm` will deprecate peer dependencies in v3, so I've updated the `package.json` to version-lock to the most recent compatible release of `dustjs-linkedin` and `adaro`.
