### PR TITLE
Use better fallback pattern

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -72,5 +72,5 @@ exports.tryRequire = function tryRequire(moduleName, fallback) {
 };
 
 exports.localityFromLocals = function localityFromLocals(locals) {
-    return locals && (locals.contentLocality || locals.locality);
+    return locals && (locals.contentLocale || locals.locale || locals.contentLocality || locals.locality);
 };


### PR DESCRIPTION
This avoids deprecation warning with older locale modules that used
res.context.
