### PR TITLE
Allow The Passthru of Missing Properties File

### DIFF
--- a/view/dust.js
+++ b/view/dust.js
@@ -40,7 +40,7 @@ exports.create = function (config) {
         global = context.global;
         locals = context.get('context');
         locality = util.localityFromLocals(locals);
-        props = res.resolve(name, locality).file || i18n.contentPath;
+        props = res.resolve(name, locality).file;
 
         options = {
             src: path.join(config.views, name + '.dust'),


### PR DESCRIPTION
Combined with this change to localizr we'll get a much better error message in the case that the props are missing:
https://github.com/krakenjs/localizr/pull/20
